### PR TITLE
Changed to allow use in Visual Studio 2019

### DIFF
--- a/AngularTemplatesExtension/source.extension.vsixmanifest
+++ b/AngularTemplatesExtension/source.extension.vsixmanifest
@@ -15,9 +15,9 @@ Creates *.service.ts for Angular services.</Description>
         <Tags>angular, angular 4, angular 5, ASP.NET Core, ngx</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0)" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0)" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -27,6 +27,6 @@ Creates *.service.ts for Angular services.</Description>
         <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="AngularWizards" d:VsixSubPath="Wizards" Path="|AngularWizards|" AssemblyName="|AngularWizards;AssemblyName|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
According to this page...
[https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/](https://madskristensen.net/blog/how-to-upgrade-extensions-to-support-visual-studio-2019/)
...this is all that is required to make this plug-in work with VS2019.

I haven't been able to test it as it didn't compile probably due to me using VS2019, so sorry, I can't even give it a ['Works on my machine'](https://blog.codinghorror.com/the-works-on-my-machine-certification-program/) sticker. I'm quite willing to test the .vsix if you send it to me, though.

On a separate topic - Thanks for creating this great plug-in. I use it all the time and it would be a shame for it to disappear.
